### PR TITLE
Fallback to ctime when mtime is not available

### DIFF
--- a/init.zsh
+++ b/init.zsh
@@ -1,11 +1,23 @@
 () {
+  builtin emulate -L zsh
   local -r target=${1}
   shift
   (( ${+commands[${1}]} )) || return 1
-  if [[ ! ( -s ${target} && ${target} -nt ${commands[${1}]} ) ]]; then
+  local -a ztimes
+  if [[ -s ${target} ]]; then
+    zmodload -F zsh/stat b:zstat && zstat -A ztimes +mtime ${commands[${1}]} ${target} || return 1
+    if [[ ${ztimes[1]} -le 1 ]]; then
+      # Fallback to ctime when mtime is not available, as can be the case with the nix store.
+      local -a zctimes
+      zstat -A zctimes +ctime ${commands[${1}]} || return 1
+      ztimes[1]=${zctimes[1]}
+    fi
+  fi
+  if [[ ${ztimes[1]} -ge ${ztimes[2]} ]]; then
     "${@}" >! ${target} || return 1
     zcompile -UR ${target}
   fi
   source ${target}
 } ${0:h}/direnv-hook-zsh.zsh direnv hook zsh || return 1
+
 if [[ -z ${NO_COLOR} && ${+DIRENV_LOG_FORMAT} -eq 0 ]] export DIRENV_LOG_FORMAT=$'\E[2mdirenv: %s\E[0m'


### PR DESCRIPTION
as can be the case with the nix store, when checking if command file was updated. I know ctime is the inode change time of the file, not its "creation" time, but the birth time is not standard nor available via zstat, so ctime is the best alternative we have. Also, the nix store should create a new subdirectory with new files for a new package version.

Fixes #1

- [x] I've followed Zim's [code style guidelines](https://github.com/zimfw/zimfw/wiki/Code-Style-Guide).
